### PR TITLE
alredy table existの時にerrorにならないように修正

### DIFF
--- a/DDL/execute_ddl.sh
+++ b/DDL/execute_ddl.sh
@@ -15,6 +15,8 @@ if [ "$1" = "local" ]; then
   DB_NAME=torimo
 fi
 
+export MYSQL_PWD=${DB_PASSWORD}
+
 for file in $(ls sql_files); do
-  mysql -u${DB_USER} -p${DB_PASSWORD} -h${DB_URL} -D${DB_NAME} -P${DB_PORT} < $PWD/sql_files/$file
+  mysql -u${DB_USER} -h${DB_URL} -D${DB_NAME} -P${DB_PORT} < $PWD/sql_files/$file
 done

--- a/DDL/sql_files/article_categories.sql
+++ b/DDL/sql_files/article_categories.sql
@@ -1,7 +1,7 @@
-CREATE TABLE `article_categories` (
+CREATE TABLE IF NOT EXISTS `article_categories` (
   `article_id` bigint NOT NULL,
   `category_id` bigint NOT NULL,
   PRIMARY KEY (`article_id`, `category_id`)
 ) ENGINE = InnoDB DEFAULT CHARSET = utf8;
 
-INSERT INTO article_categories VALUES ('1', '1');
+INSERT IGNORE INTO article_categories VALUES ('1', '1');

--- a/DDL/sql_files/article_likes.sql
+++ b/DDL/sql_files/article_likes.sql
@@ -1,8 +1,8 @@
-CREATE TABLE `article_likes` (
+CREATE TABLE IF NOT EXISTS `article_likes` (
   `id` bigint NOT NULL AUTO_INCREMENT,
   `user_id` bigint NOT NULL,
   `article_id` bigint NOT NULL,
   PRIMARY KEY (`id`)
 ) ENGINE = InnoDB DEFAULT CHARSET = utf8;
 
-INSERT INTO article_likes VALUES ('1', '1', '1');
+INSERT IGNORE INTO article_likes VALUES ('1', '1', '1');

--- a/DDL/sql_files/articles.sql
+++ b/DDL/sql_files/articles.sql
@@ -1,4 +1,4 @@
-CREATE TABLE `articles` (
+CREATE TABLE IF NOT EXISTS `articles` (
   `id` bigint NOT NULL AUTO_INCREMENT,
   `title` varchar(100) NOT NULL,
   `user_id` bigint NOT NULL,
@@ -10,7 +10,7 @@ CREATE TABLE `articles` (
   PRIMARY KEY (`id`)
 ) ENGINE = InnoDB DEFAULT CHARSET = utf8;
 
-INSERT INTO
+INSERT IGNORE INTO
 articles
 (`title`,
  `user_id`,

--- a/DDL/sql_files/categories.sql
+++ b/DDL/sql_files/categories.sql
@@ -1,4 +1,4 @@
-CREATE TABLE `categories` (
+CREATE TABLE IF NOT EXISTS `categories` (
   `id` bigint NOT NULL AUTO_INCREMENT,
   `name` varchar(50) NOT NULL,
   `create_user` bigint NOT NULL DEFAULT 1,
@@ -8,7 +8,7 @@ CREATE TABLE `categories` (
   PRIMARY KEY (`id`)
 ) ENGINE = InnoDB DEFAULT CHARSET = utf8;
 
-INSERT INTO
+INSERT IGNORE INTO
 categories
 (`name`,
  `create_user`,

--- a/DDL/sql_files/follow_users.sql
+++ b/DDL/sql_files/follow_users.sql
@@ -1,8 +1,8 @@
-CREATE TABLE `follow_users` (
+CREATE TABLE IF NOT EXISTS `follow_users` (
   `id` bigint NOT NULL AUTO_INCREMENT,
   `from_user` bigint NOT NULL,
   `to_user` bigint NOT NULL,
   PRIMARY KEY (`id`)
 ) ENGINE = InnoDB DEFAULT CHARSET = utf8;
 
-INSERT INTO follow_users VALUES ('1', '1', '2');
+INSERT IGNORE INTO follow_users VALUES ('1', '1', '2');

--- a/DDL/sql_files/shops.sql
+++ b/DDL/sql_files/shops.sql
@@ -1,4 +1,4 @@
-CREATE TABLE `shops` (
+CREATE TABLE IF NOT EXISTS `shops` (
   `id` bigint NOT NULL AUTO_INCREMENT,
   `name` varchar(100) NOT NULL,
   `station_id` bigint DEFAULT 0,
@@ -9,7 +9,7 @@ CREATE TABLE `shops` (
   PRIMARY KEY (`id`)
 ) ENGINE = InnoDB DEFAULT CHARSET = utf8;
 
-INSERT INTO
+INSERT IGNORE INTO
 shops
 (`name`,
  `create_user`,

--- a/DDL/sql_files/users.sql
+++ b/DDL/sql_files/users.sql
@@ -1,4 +1,4 @@
-CREATE TABLE `users` (
+CREATE TABLE IF NOT EXISTS `users` (
   `id` bigint NOT NULL AUTO_INCREMENT,
   `name` varchar(32) NOT NULL,
   `external_service_id` varchar(50) NOT NULL,
@@ -10,7 +10,7 @@ CREATE TABLE `users` (
   PRIMARY KEY (`id`)
 ) ENGINE = InnoDB DEFAULT CHARSET = utf8;
 
-INSERT INTO
+INSERT IGNORE INTO
 users
 (`name`,
  `external_service_id`,


### PR DESCRIPTION
- create文に`IF NOT EXISTS`をつけてテーブルが存在しないときだけcreateされるように修正。
- insert文には`IGNORE`をつけてinsert文がエラーの時は握りつぶすように修正。
  - 最初のテストデータを入れるinsert文なのでerrorが起きるとしても原因はpkeyの重複とかだと思うので、最初のデータさえ挿入できればいいと思うので。

参考：
http://oomatomo.hatenablog.com/entry/33737434